### PR TITLE
feat: Filter by allowed extensions ['image/png', 'image/jpg'] or ['jp…

### DIFF
--- a/src/image-upload.directive.ts
+++ b/src/image-upload.directive.ts
@@ -12,6 +12,7 @@ export class ImageUploadDirective {
     @Output() imageSelected = new EventEmitter<ImageResult>();
 
     @Input() resizeOptions: ResizeOptions;
+    @Input() allowedExtensions: string[];
 
     constructor(private _elementref: ElementRef, private _renderer: Renderer) {
     }
@@ -23,6 +24,10 @@ export class ImageUploadDirective {
                 file: file,
                 url: URL.createObjectURL(file)
             };
+            let ext: string = file.name.split('.').pop();
+            if (!!this.allowedExtensions.length && this.allowedExtensions.indexOf(ext) === -1 ) {
+                result.error = 'Extension Not Allowed';
+            }
             this.fileToDataURL(file, result).then(r => this.resize(r)).then(r => this.imageSelected.emit(r));
         }
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ export interface ImageResult {
     file: File;
     url: string;
     dataURL?: string;
+    error?: string;
     resized?: {
         dataURL: string;
         type: string;


### PR DESCRIPTION
…g', 'png']

To include error message so this error message can be display to users who attempt to upload not allowed extension.

Referencing #5